### PR TITLE
Files in manifest

### DIFF
--- a/.bugs/bugs
+++ b/.bugs/bugs
@@ -1,7 +1,7 @@
 use logging from standardlib for logging                     | owner:Arne Babenhauserheide <bab@draketo.de>, open:True, id:67881d1b9904ff1f140d28c22c0796b0b9449414, time:1359301941.59
 cleanup the setup.py: Get rid of the always executed man-file install. | owner:, open:True, id:a576c319caf21ad83191e4a4102f4770873f3d73, time:1410005559.52
 lots of unicode stuff with non-ascii filenmaes.              | owner:, open:True, id:c441021af289f677abf8a8d2a4500d1e67db4776, time:1410909139.31
-fcpupload does not work right now. Maybe due to an upload of a big folder. Still to fix. | owner:, open:True, id:c79825b05babe041ce1245b9d8de98900cac72d3, time:1411041961.0
+fcpupload does not work right now. Maybe due to an upload of a big folder. Still to fix. | owner:, open:False, id:c79825b05babe041ce1245b9d8de98900cac72d3, time:1411041961.0
 switch to argparse                                           | owner:, open:True, id:c7c6938b8dda3c2cd3277c378f9c9252c977d81b, time:1409904761.93
 sitemgr seems to have problems with .tar.bz2 archives. Maybe still errors from the mimetype. That seems to give a list for tar.bz2, not a string. | owner:, open:True, id:d08ce76ba39759e1276b54310f6def22cbc96624, time:1410989517.13
 add my site to the bookmarks                                 | owner:, open:True, id:e4f9b8d14378032a2ef2fa25c55004695e7a3ef2, time:1409904753.26

--- a/.bugs/bugs
+++ b/.bugs/bugs
@@ -2,4 +2,5 @@ use logging from standardlib for logging                     | owner:Arne Babenh
 cleanup the setup.py: Get rid of the always executed man-file install. | owner:, open:True, id:a576c319caf21ad83191e4a4102f4770873f3d73, time:1410005559.52
 lots of unicode stuff with non-ascii filenmaes.              | owner:, open:True, id:c441021af289f677abf8a8d2a4500d1e67db4776, time:1410909139.31
 switch to argparse                                           | owner:, open:True, id:c7c6938b8dda3c2cd3277c378f9c9252c977d81b, time:1409904761.93
+sitemgr seems to have problems with .tar.bz2 archives. Maybe still errors from the mimetype. That seems to give a list for tar.bz2, not a string. | owner:, open:True, id:d08ce76ba39759e1276b54310f6def22cbc96624, time:1410989517.13
 add my site to the bookmarks                                 | owner:, open:True, id:e4f9b8d14378032a2ef2fa25c55004695e7a3ef2, time:1409904753.26

--- a/.bugs/bugs
+++ b/.bugs/bugs
@@ -1,4 +1,5 @@
 use logging from standardlib for logging                     | owner:Arne Babenhauserheide <bab@draketo.de>, open:True, id:67881d1b9904ff1f140d28c22c0796b0b9449414, time:1359301941.59
 cleanup the setup.py: Get rid of the always executed man-file install. | owner:, open:True, id:a576c319caf21ad83191e4a4102f4770873f3d73, time:1410005559.52
+lots of unicode stuff with non-ascii filenmaes.              | owner:, open:True, id:c441021af289f677abf8a8d2a4500d1e67db4776, time:1410909139.31
 switch to argparse                                           | owner:, open:True, id:c7c6938b8dda3c2cd3277c378f9c9252c977d81b, time:1409904761.93
 add my site to the bookmarks                                 | owner:, open:True, id:e4f9b8d14378032a2ef2fa25c55004695e7a3ef2, time:1409904753.26

--- a/.bugs/bugs
+++ b/.bugs/bugs
@@ -1,6 +1,7 @@
 use logging from standardlib for logging                     | owner:Arne Babenhauserheide <bab@draketo.de>, open:True, id:67881d1b9904ff1f140d28c22c0796b0b9449414, time:1359301941.59
 cleanup the setup.py: Get rid of the always executed man-file install. | owner:, open:True, id:a576c319caf21ad83191e4a4102f4770873f3d73, time:1410005559.52
 lots of unicode stuff with non-ascii filenmaes.              | owner:, open:True, id:c441021af289f677abf8a8d2a4500d1e67db4776, time:1410909139.31
+fcpupload does not work right now. Maybe due to an upload of a big folder. Still to fix. | owner:, open:True, id:c79825b05babe041ce1245b9d8de98900cac72d3, time:1411041961.0
 switch to argparse                                           | owner:, open:True, id:c7c6938b8dda3c2cd3277c378f9c9252c977d81b, time:1409904761.93
 sitemgr seems to have problems with .tar.bz2 archives. Maybe still errors from the mimetype. That seems to give a list for tar.bz2, not a string. | owner:, open:True, id:d08ce76ba39759e1276b54310f6def22cbc96624, time:1410989517.13
 add my site to the bookmarks                                 | owner:, open:True, id:e4f9b8d14378032a2ef2fa25c55004695e7a3ef2, time:1409904753.26

--- a/.bugs/bugs
+++ b/.bugs/bugs
@@ -1,3 +1,4 @@
 use logging from standardlib for logging                     | owner:Arne Babenhauserheide <bab@draketo.de>, open:True, id:67881d1b9904ff1f140d28c22c0796b0b9449414, time:1359301941.59
+cleanup the setup.py: Get rid of the always executed man-file install. | owner:, open:True, id:a576c319caf21ad83191e4a4102f4770873f3d73, time:1410005559.52
 switch to argparse                                           | owner:, open:True, id:c7c6938b8dda3c2cd3277c378f9c9252c977d81b, time:1409904761.93
 add my site to the bookmarks                                 | owner:, open:True, id:e4f9b8d14378032a2ef2fa25c55004695e7a3ef2, time:1409904753.26

--- a/.bugs/bugs
+++ b/.bugs/bugs
@@ -1,1 +1,3 @@
 use logging from standardlib for logging                     | owner:Arne Babenhauserheide <bab@draketo.de>, open:True, id:67881d1b9904ff1f140d28c22c0796b0b9449414, time:1359301941.59
+switch to argparse                                           | owner:, open:True, id:c7c6938b8dda3c2cd3277c378f9c9252c977d81b, time:1409904761.93
+add my site to the bookmarks                                 | owner:, open:True, id:e4f9b8d14378032a2ef2fa25c55004695e7a3ef2, time:1409904753.26

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -2124,7 +2124,7 @@ class FCPNode:
         
         job.followRedirect = followRedirect
     
-        if cmd == 'ClientGet':
+        if cmd == 'ClientGet' and 'URI' in kw:
             job.uri = kw['URI']
     
         if cmd == 'ClientPut':
@@ -2313,9 +2313,11 @@ class FCPNode:
         # handle ClientPut responses
     
         if hdr == 'URIGenerated':
-    
-            job.uri = msg['URI']
-            newUri = msg['URI']
+            if 'URI' not in msg:
+                log(ERROR, "message {} without 'URI'. This is very likely a bug in Freenet. Check whether you have files in uploads or downloads without URI (clickable link).".format(hdr))
+            else:
+                job.uri = msg['URI']
+                newUri = msg['URI']
             job.callback('pending', msg)
     
             return
@@ -2327,9 +2329,12 @@ class FCPNode:
                 return
     
         if hdr == 'PutSuccessful':
-            result = msg['URI']
             job.callback('successful', result)
-            job._putResult(result)
+            if 'URI' not in msg:
+                log(ERROR, "message {} without 'URI'. This is very likely a bug in Freenet. Check whether you have files in uploads or downloads without URI (clickable link).".format(hdr))
+            else:
+                result = msg['URI']
+                job._putResult(result)
             #print "*** PUTSUCCESSFUL"
             return
     
@@ -2339,8 +2344,11 @@ class FCPNode:
             return
         
         if hdr == 'PutFetchable':
-            uri = msg['URI']
-            job.kw['URI'] = uri
+            if 'URI' not in msg:
+                log(ERROR, "message {} without 'URI'. This is very likely a bug in Freenet. Check whether you have files in uploads or downloads without URI (clickable link).".format(hdr))
+            else:
+                uri = msg['URI']
+                job.kw['URI'] = uri
             job.callback('pending', msg)
             return
     

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -2096,6 +2096,15 @@ class FCPNode:
             - if command is sent in sync mode, returns the result
             - if command is sent in async mode, returns a JobTicket
               object which the client can poll or block on later
+
+        >>> import fcp
+        >>> n = fcp.node.FCPNode()
+        >>> cmd = "ClientPut"
+        >>> jobid = "id2291160822224650"
+        >>> opts = {'Metadata.ContentType': 'text/html', 'async': False, 'UploadFrom': 'direct', 'Verbosity': 0, 'Global': 'false', 'URI': 'CHK@', 'keep': False, 'DontCompress': 'false', 'MaxRetries': -1, 'timeout': 31536000, 'Codecs': 'GZIP, BZIP2, LZMA, LZMA_NEW', 'GetCHKOnly': 'true', 'RealTimeFlag': 'false', 'waituntilsent': False, 'Identifier': jobid, 'Data': '<!DOCTYPE html>\n<html>\n<head>\n<title>Sitemap for freenet-plugin-bare</title>\n</head>\n<body>\n<h1>Sitemap for freenet-plugin-bare</h1>\nThis listing was automatically generated and inserted by freesitemgr\n<br><br>\n<table cellspacing=0 cellpadding=2 border=0>\n<tr>\n<td><b>Size</b></td>\n<td><b>Mimetype</b></td>\n<td><b>Name</b></td>\n</tr>\n<tr>\n<td>19211</td>\n<td>text/html</td>\n<td><a href="index.html">index.html</a></td>\n</tr>\n</table>\n<h2>Keys of large, separately inserted files</h2>\n<pre>\n</pre></body></html>\n', 'PriorityClass': 3, 'Persistence': 'connection', 'TargetFilename': 'sitemap.html'}
+        >>> n._submitCmd(jobid, cmd, **opts)
+        'CHK@FR~anQPhpw7lZjxl96o1b875tem~5xExPTiSa6K3Wus,yuGOWhpqFY5N9i~N4BjM0Oh6Bk~Kkb7sE4l8GAsdBEs,AAMC--8/sitemap.html'
+        
         """
         if not self.nodeIsAlive:
             raise FCPNodeFailure("%s:%s: node closed connection" % (cmd, id))

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -2104,6 +2104,7 @@ class FCPNode:
         >>> opts = {'Metadata.ContentType': 'text/html', 'async': False, 'UploadFrom': 'direct', 'Verbosity': 0, 'Global': 'false', 'URI': 'CHK@', 'keep': False, 'DontCompress': 'false', 'MaxRetries': -1, 'timeout': 31536000, 'Codecs': 'GZIP, BZIP2, LZMA, LZMA_NEW', 'GetCHKOnly': 'true', 'RealTimeFlag': 'false', 'waituntilsent': False, 'Identifier': jobid, 'Data': '<!DOCTYPE html>\n<html>\n<head>\n<title>Sitemap for freenet-plugin-bare</title>\n</head>\n<body>\n<h1>Sitemap for freenet-plugin-bare</h1>\nThis listing was automatically generated and inserted by freesitemgr\n<br><br>\n<table cellspacing=0 cellpadding=2 border=0>\n<tr>\n<td><b>Size</b></td>\n<td><b>Mimetype</b></td>\n<td><b>Name</b></td>\n</tr>\n<tr>\n<td>19211</td>\n<td>text/html</td>\n<td><a href="index.html">index.html</a></td>\n</tr>\n</table>\n<h2>Keys of large, separately inserted files</h2>\n<pre>\n</pre></body></html>\n', 'PriorityClass': 3, 'Persistence': 'connection', 'TargetFilename': 'sitemap.html'}
         >>> n._submitCmd(jobid, cmd, **opts)
         'CHK@FR~anQPhpw7lZjxl96o1b875tem~5xExPTiSa6K3Wus,yuGOWhpqFY5N9i~N4BjM0Oh6Bk~Kkb7sE4l8GAsdBEs,AAMC--8/sitemap.html'
+        >>> # n._submitCmd(id=None, cmd='WatchGlobal', **{'Enabled': 'true'})
         
         """
         if not self.nodeIsAlive:
@@ -2111,7 +2112,7 @@ class FCPNode:
     
         log = self._log
     
-        log(DEBUG, "_submitCmd: cmd=%s, kw=%s" % (cmd, kw))
+        log(DEBUG, "_submitCmd: id=" + repr(id) + ", cmd=" + repr(cmd) + ", **" + repr(kw))
     
         async = kw.pop('async', False)
         followRedirect = kw.pop('followRedirect', True)
@@ -2141,10 +2142,10 @@ class FCPNode:
     
         self.clientReqQueue.put(job)
     
-        log(DEBUG, "_submitCmd: id=%s cmd=%s kw=%s" % (id, cmd, # truncate long commands
-                                                       str([(k,str(kw.get(k, ""))[:128])
-                                                            for k 
-                                                            in kw])))
+        # log(DEBUG, "_submitCmd: id='%s' cmd='%s' kw=%s" % (id, cmd, # truncate long commands
+        #                                                    str([(k,str(kw.get(k, ""))[:128])
+        #                                                         for k 
+        #                                                         in kw])))
     
     
         if async:

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -2329,13 +2329,13 @@ class FCPNode:
                 return
     
         if hdr == 'PutSuccessful':
-            job.callback('successful', result)
             if 'URI' not in msg:
                 log(ERROR, "message {} without 'URI'. This is very likely a bug in Freenet. Check whether you have files in uploads or downloads without URI (clickable link).".format(hdr))
             else:
                 result = msg['URI']
                 job._putResult(result)
-            #print "*** PUTSUCCESSFUL"
+                job.callback('successful', result)
+            # print "*** PUTSUCCESSFUL"
             return
     
         if hdr == 'PutFailed':

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -46,6 +46,8 @@ import unicodedata
 
 import pseudopythonparser
 
+_pollInterval = 0.03
+
 #@-node:imports
 #@+node:exceptions
 class ConnectionRefused(Exception):
@@ -1022,12 +1024,12 @@ class FCPNode:
         
                 # wait and go round again if concurrent inserts are maxed
                 if nInserting >= maxConcurrent:
-                    time.sleep(0.03)
+                    time.sleep(_pollInterval)
                     continue
         
                 # just go round again if manifest is empty (all remaining are in progress)
                 if len(manifest) == 0:
-                    time.sleep(0.03)
+                    time.sleep(_pollInterval)
                     continue
         
                 # got >0 waiting jobs and >0 spare slots, so we can submit a new one
@@ -2128,7 +2130,7 @@ class FCPNode:
     
         self.clientReqQueue.put(job)
     
-        log(DEBUG, "_submitCmd: id=%s cmd=%s kw=%s" % (id, cmd, 
+        log(DEBUG, "_submitCmd: id=%s cmd=%s kw=%s" % (id, cmd, # truncate long commands
                                                        str([(k,str(kw.get(k, ""))[:128])
                                                             for k 
                                                             in kw])))
@@ -2924,7 +2926,7 @@ class JobTicket:
         if timeout == None:
             log(DEBUG, "wait:%s:%s: no timeout" % (self.cmd, self.id))
             while not self.lock.acquire(False):
-                time.sleep(0.03)
+                time.sleep(_pollInterval)
             self.lock.release()
             return self.getResult()
     
@@ -2940,7 +2942,7 @@ class JobTicket:
             # got any time left?
             if elapsed < timeout:
                 # yep, patience remains
-                time.sleep(0.03)
+                time.sleep(_pollInterval)
                 log(DEBUG, "wait:%s:%s: job not dispatched, timeout in %ss" % \
                      (self.cmd, self.id, timeout-elapsed))
                 continue
@@ -2961,7 +2963,7 @@ class JobTicket:
             # got any time left?
             if elapsed < timeout:
                 # yep, patience remains
-                time.sleep(0.03)
+                time.sleep(_pollInterval)
     
                 #print "** lock=%s" % self.lock
     

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -702,7 +702,8 @@ class FCPNode:
         opts['RealTimeFlag'] = toBool(kw.get("realtime", "false"))
         opts['GetCHKOnly'] = chkOnly
         opts['DontCompress'] = toBool(kw.get("nocompress", "false"))
-        opts['Codecs'] = kw.get('Codecs', ", ".join([name for name, num in self.compressionCodecs]))
+        opts['Codecs'] = kw.get('Codecs', 
+                                self.defaultCompressionCodecsString())
         
         if kw.has_key("file"):
             filepath = os.path.abspath(kw['file'])
@@ -840,7 +841,8 @@ class FCPNode:
         if not id:
             id = self._getUniqueId()
 
-        codecs = kw.get('Codecs', ", ".join([name for name, num in self.compressionCodecs]))
+        codecs = kw.get('Codecs', 
+                        self.defaultCompressionCodecsString())
         
         # derive final URI for insert
         uriFull = uri + sitename + "/"
@@ -2636,6 +2638,17 @@ class FCPNode:
                     for i in CompressionCodecsString.split(
                             " - ")[1].split(", ")]]
     #@-node:_parseCompressionCodecs
+    #@+node:defaultCompressionCodecsString
+    def defaultCompressionCodecsString(self):
+        """
+        Turn the CompressionCodecs into a string accepted by the node.
+
+        @param CompressionCodecs: [(name, number), ...]
+        @return: "GZIP, BZIP2, LZMA" (example)
+
+        """
+        return ", ".join([name for name, num in self.compressionCodecs])
+    #@-node:defaultCompressionCodecsString
     #@+node:_getUniqueId
     def _getUniqueId(self):
         """

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -725,6 +725,10 @@ class FCPNode:
             opts["TargetURI"] = kw['redirect']
         elif chkOnly != "true":
             raise Exception("Must specify file, data or redirect keywords")
+        
+        if "TargetFilename" in kw: # for CHKs
+            opts["TargetFilename"] = kw["TargetFilename"]
+            
     
         opts['timeout'] = int(kw.get("timeout", ONE_YEAR))
     

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -833,6 +833,8 @@ class FCPNode:
         id = kw.pop("id", None)
         if not id:
             id = self._getUniqueId()
+
+        codecs = kw.get('Codecs', ", ".join([name for name, num in self.compressionCodecs]))
         
         # derive final URI for insert
         uriFull = uri + sitename + "/"
@@ -924,6 +926,7 @@ class FCPNode:
                             "MaxRetries=%s" % maxretries,
                             "PriorityClass=%s" % priority,
                             "URI=%s" % uriFull,
+                            "Codecs=%s" % codecs,
                             #"Persistence=%s" % kw.get("persistence", "connection"),
                             "DefaultName=index.html",
                             ]
@@ -1078,6 +1081,7 @@ class FCPNode:
                     "MaxRetries=%s" % maxretries,
                     "PriorityClass=%s" % priority,
                     "URI=%s" % uriFull,
+                    "Codecs=%s" % codecs,
                     #"Persistence=%s" % kw.get("persistence", "connection"),
                     "DefaultName=index.html",
                     ]

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -2120,7 +2120,10 @@ class FCPNode:
     
         self.clientReqQueue.put(job)
     
-        log(DEBUG, "_submitCmd: id=%s cmd=%s kw=%s" % (id, cmd, str(kw)[:256]))
+        log(DEBUG, "_submitCmd: id=%s cmd=%s kw=%s" % (id, cmd, 
+                                                       str([(k,str(kw.get(k, ""))[:128])
+                                                            for k 
+                                                            in kw])))
     
     
         if async:

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -3237,7 +3237,7 @@ def guessMimetype(filename):
     return m
 
 
-_re_slugify = re.compile('[^\w\s-]', re.UNICODE)
+_re_slugify = re.compile('[^\w\s\.-]', re.UNICODE)
 _re_slugify_multidashes = re.compile('[-\s]+', re.UNICODE)
 def toUrlsafe(filename):
     """Make a filename url-safe, keeping only the basename and killing all

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -700,7 +700,7 @@ class FCPNode:
         opts['RealTimeFlag'] = toBool(kw.get("realtime", "false"))
         opts['GetCHKOnly'] = chkOnly
         opts['DontCompress'] = toBool(kw.get("nocompress", "false"))
-        opts['Codecs'] = kw.get('Codecs', ", ".join([name for name, num in self.node.compressionCodecs]))
+        opts['Codecs'] = kw.get('Codecs', ", ".join([name for name, num in self.compressionCodecs]))
         
         if kw.has_key("file"):
             filepath = os.path.abspath(kw['file'])

--- a/fcp/node.py
+++ b/fcp/node.py
@@ -2620,6 +2620,14 @@ class FCPNode:
     #@-node:_hello
     #@+node:_parseCompressionCodecs
     def _parseCompressionCodecs(self, CompressionCodecsString):
+        """
+        Turn the CompressionCodecsString returned by the node into a list
+        of name and number of the codec.
+
+        @param CompressionCodecsString: "3 - GZIP(0), BZIP2(1), LZMA(2)"
+        @return: [(name, number), ...]
+
+        """
         return [(name, int(number[:-1])) 
                 for name, number 
                 in [i.split("(") 

--- a/fcp/pseudopythonparser.py
+++ b/fcp/pseudopythonparser.py
@@ -76,6 +76,7 @@ class Parser:
         if self.unparsed and not self.endunparsed:
             raise ValueError("We have unparsed data but we do not know how it ends. THIS IS A BUG.")
         
+        # this takes 90% of the time in this function.
         if self.unparsed and self.endunparsed:
             self.unparsed += "\n" + line
         

--- a/fcp/pseudopythonparser.py
+++ b/fcp/pseudopythonparser.py
@@ -55,7 +55,9 @@ class Parser:
             "),", "],").replace(
             # json cannot handle unicode string markers
             ' u"', ' "').replace(
-            ' [u"', ' ["')
+            ' [u"', ' ["').replace(
+            " u'", " '").replace(
+            " [u'", " ['")
         try:
             return json.loads(text+"\n")
         except ValueError:

--- a/fcp/pseudopythonparser.py
+++ b/fcp/pseudopythonparser.py
@@ -64,8 +64,8 @@ class Parser:
             print text
             raise
     
-    def checkandprocesslinerest(self, unparsed):
-        """Check if the rest of the line finishes the line."""
+    def checkandprocessunprocessed(self):
+        """Check if the rest of self.unprocessed finishes the line."""
         if self.endunparsed in self.unparsed:
             self.data[self.unparsedvariable] = self.jsonload(self.unparsed)
             self.unparsed, self.unparsedvariable, self.endunparsed = "", "", ""
@@ -96,14 +96,14 @@ class Parser:
             self.unparsedvariable = line[:start]
             self.unparsed = line[start+3:]
             self.endunparsed = "]"
-            self.checkandprocesslinerest(self.unparsed)
+            self.checkandprocessunprocessed()
             return
         elif " = {" in line:
             start = line.index(" = {")
             self.unparsedvariable = line[:start]
             self.unparsed = line[start+3:]
             self.endunparsed = "}"
-            self.checkandprocesslinerest(self.unparsed)
+            self.checkandprocessunprocessed()
             return
         
         # handle the easy cases

--- a/fcp/pseudopythonparser.py
+++ b/fcp/pseudopythonparser.py
@@ -72,23 +72,22 @@ class Parser:
     
     def readline(self, line):
         """Read one line of text."""
-        # check unparsed code
-        if self.unparsed:
-            if not self.endunparsed:
-                raise ValueError("We have unparsed data but we do not know how it ends." 
-                                 "THIS IS A BUG.")
-            else:
-                self.unparsed += "\n" + line
-                # if the line ends the unparsed code, store it.
-                if line.strip().endswith(self.endunparsed):
-                    # json uses null for None, true for True and false for False. 
-                    # We have to replace those in the content and hope that nothing will break.
-                    self.data[self.unparsedvariable] = self.jsonload(self.unparsed)
-                    self.unparsed, self.endunparsed = "", ""
-                # if the line does not end the unparsed code, just
-                # keep the code we added to the unparsed code
-                return
-                
+        # if we have unparsed code and this line does not end it, we just add the code to the unparsed code.
+        if self.unparsed and not self.endunparsed:
+            raise ValueError("We have unparsed data but we do not know how it ends. THIS IS A BUG.")
+        
+        if self.unparsed and self.endunparsed:
+            self.unparsed += "\n" + line
+        
+        if self.unparsed and self.endunparsed and not line.strip().endswith(self.endunparsed):
+            return # line is already processed as far as possible
+        if self.unparsed and self.endunparsed and line.strip().endswith(self.endunparsed):
+            # json uses null for None, true for True and false for False. 
+            # We have to replace those in the content and hope that nothing will break.
+            data = self.jsonload(self.unparsed)
+            self.data[self.unparsedvariable] = data
+            self.unparsed, self.endunparsed = "", ""
+            return
         
         # start reading complex datastructures
         if " = [" in line:
@@ -98,7 +97,7 @@ class Parser:
             self.endunparsed = "]"
             self.checkandprocesslinerest(self.unparsed)
             return
-        if " = {" in line:
+        elif " = {" in line:
             start = line.index(" = {")
             self.unparsedvariable = line[:start]
             self.unparsed = line[start+3:]
@@ -107,17 +106,19 @@ class Parser:
             return
         
         # handle the easy cases
-        if (not line.strip()                # ignore empty lines
-            or line.strip().startswith("#") # ignore comments
-            or not " = " in line):          # the only thing left to
-                                            # care for are variable
-                                            # assignments
+        # ignore empty lines
+        if not line.strip():
+            return
+        # ignore comments
+        if line.strip().startswith("#"):
+            return
+        # the only thing left to care for are variable assignments
+        if not " = " in line:
             return
         
         # prepare reading variables
         start = line.index(" = ")
         variable = line[:start]
-        # TODO: use a pre-created regexp for higher speed.
         forbiddenvariablechars = " ", ".", "+", "-", "=", "*", "/"
         if True in [i in variable for i in forbiddenvariablechars]:
             raise ValueError("Variables must not contain any of the forbidden characters: " + str(forbiddenvariablechars))

--- a/fcp/pseudopythonparser.py
+++ b/fcp/pseudopythonparser.py
@@ -81,7 +81,7 @@ class Parser:
                 raise
     
     # FIXME: Using a property here might be confusing, because I assign
-    #        directly to unparsed.
+    #        directly to unparsed. Check whether there’s a cleaner way.
     @property
     def unparsedstring(self):
         """Join and return self.unparsed as a string."""

--- a/fcp/pseudopythonparser.py
+++ b/fcp/pseudopythonparser.py
@@ -80,6 +80,8 @@ class Parser:
                 print text
                 raise
     
+    # FIXME: Using a property here might be confusing, because I assign
+    #        directly to unparsed.
     @property
     def unparsedstring(self):
         """Join and return self.unparsed as a string."""

--- a/fcp/pseudopythonparser.py
+++ b/fcp/pseudopythonparser.py
@@ -59,6 +59,8 @@ class Parser:
         try:
             return json.loads(text+"\n")
         except ValueError:
+            # on old freesitemrg site entries json can break, so it
+            # needs some manual conversion.
             # json uses " for strings but never '. Python may use '
             # for backwards compatibility we have to treat this correctly.
             # If there are two " in a line, then every ' must be escaped 

--- a/fcp/pseudopythonparser.py
+++ b/fcp/pseudopythonparser.py
@@ -134,6 +134,12 @@ class Parser:
         if rest in safevalues:
             self.data[variable] = eval(rest)
             return
+
+        # handle json literals
+        safevalues = "true", "false", "null" 
+        if rest in safevalues:
+            self.data[variable] = json.loads(rest)
+            return
         
         # handle numbers: these are safe to eval, too
         numberchars = set(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "."])
@@ -145,6 +151,7 @@ class Parser:
         if rest.startswith("'") and rest.endswith("'") or rest.startswith('"') and rest.endswith('"'):
             self.data[variable] = rest[1:-1]
             return
+        
         
         # if we did not return by now, the file is malformed (or too complex)
         raise ValueError("Invalid or too complex code: " + line)

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1240,7 +1240,7 @@ class SiteState:
                 lines.extend([
                     "<tr>",
                     "<td>%s</td>" % size,
-                    "<td>%s</td>" % mimetype,
+                    "<td>%s</td>" % str(mimetype), # TODO: check: mimetype for tar.b2 is a list?
                     "<td><a href=\"%s\">%s</a></td>" % (name, name),
                     "</tr>",
                     ])

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1529,6 +1529,8 @@ class SiteState:
         # FIXME: Reports an erroneous Error when no physical index is present.
         reportedlength = sum(rec['sizebytes'] for rec in self.files
                              if rec.get('target', 'separate') == 'manifest')
+        if self.indexRec not in self.files:
+            reportedlength += self.indexRec['sizebytes']
         if datalength != reportedlength:
             self.log(ERROR, "The datalength of %s to be uploaded does not match the length reported to the node of %s. This is a bug, please report it to the pyFreenet maintainer." % (datalength, reportedlength))
 

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1443,7 +1443,7 @@ class SiteState:
                     "Files.%d.TargetURI=%s" % (n, rec['uri']),
                 ]
             # if the site should be part of the manifest, check for DDA
-            if not 'path' in rec:
+            if 'path' not in rec:
                 hasDDA = False
             else:
                 DDAdir = os.path.dirname(rec['path'])

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1526,6 +1526,7 @@ class SiteState:
         self.manifestCmdBuf = b"\n".join(i.encode("utf-8") for i in msgLines) + b"\n"
         self.manifestCmdBuf += b"".join(datatoappend)
         datalength = len(b"".join(datatoappend))
+        # FIXME: Reports an erroneous Error when no physical index is present.
         reportedlength = sum(rec['sizebytes'] for rec in self.files
                              if rec.get('target', 'separate') == 'manifest')
         if datalength != reportedlength:

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1211,9 +1211,13 @@ class SiteState:
             indexlines.append("</table></body></html>\n")
             
             self.indexRec = {'name': self.index, 'state': 'changed'}
-            self.generatedTextData[self.indexRec['name']] = "\n".join(indexlines)
-            self.indexRec['sizebytes'] = len(
-                self.generatedTextData[self.indexRec['name']].encode("utf-8"))
+            self.generatedTextData[self.indexRec['name']] = "\n".join([unicode(i, encoding="utf-8") for i in indexlines])
+            try:
+                self.indexRec['sizebytes'] = len(
+                    self.generatedTextData[self.indexRec['name']].encode("utf-8"))
+            except UnicodeDecodeError:
+                print "generated data:", self.generatedTextData[self.indexRec['name']]
+                raise
             # needs no URI: is always in manifest.
 
         def createsitemap():

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1068,15 +1068,14 @@ class SiteState:
             elif rec['state'] in ('changed', 'waiting'):
                 # already known to be changed
                 structureChanged = True
-            elif not rec.get('uri', None):
+            elif (not rec.get('uri', None) and 
+                  rec.get('target', 'separate') == 'separate'):
+                # file has no URI but was not part of a container
                 structureChanged = True
                 rec['state'] = 'changed'
         
         # secondly, add new/changed files we just checked on disk
         for name, rec in physDict.items():
-            # generated files never trigger a reupload.
-            if name in self.generatedTextData:
-                continue
             if name not in self.filesDict:
                 # new file - add it and flag update
                 log(DETAIL, "scan: file %s has been added" % name)

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1270,7 +1270,7 @@ class SiteState:
             lines.append("</pre></body></html>\n")
             
             self.sitemapRec = {'name': self.sitemap, 'state': 'changed', 'mimetype': 'text/html'}
-            self.generatedTextData[self.sitemapRec['name']] = "\n".join(lines)
+            self.generatedTextData[self.sitemapRec['name']] = "\n".join(l.decode("utf-8") for l in lines)
             raw = self.generatedTextData[self.sitemapRec['name']].encode("utf-8")
             self.sitemapRec['sizebytes'] = len(raw)
             self.sitemapRec['uri'] = self.chkCalcNode.genchk(
@@ -1363,37 +1363,37 @@ class SiteState:
         # now resort the recBySize to have the recs which are
         # referenced in index first - with additional preference to CSS files.
         fileNamesInIndex = set([rec['name'] for rec in recBySize 
-                                if rec['name'] in indexText])
+                                if rec['name'].decode("utf-8") in indexText])
         fileNamesInIndexCSS = set([rec['name'] for rec in recBySize 
-                                   if rec['name'] in fileNamesInIndex 
-                                   and rec['name'].lower().endswith('.css')])
+                                   if rec['name'].decode("utf-8") in fileNamesInIndex 
+                                   and rec['name'].decode("utf-8").lower().endswith('.css')])
         fileNamesInManifest = set()
         recByIndexAndSize = []
         recByIndexAndSize.extend(rec for rec in recBySize 
-                                 if rec['name'] in fileNamesInIndexCSS)
+                                 if rec['name'].decode("utf-8") in fileNamesInIndexCSS)
         recByIndexAndSize.extend(rec for rec in recBySize 
-                                 if rec['name'] in fileNamesInIndex
-                                 and rec['name'] not in fileNamesInIndexCSS)
+                                 if rec['name'].decode("utf-8") in fileNamesInIndex
+                                 and rec['name'].decode("utf-8") not in fileNamesInIndexCSS)
         recByIndexAndSize.extend(rec for rec in recBySize 
-                                 if rec['name'] not in fileNamesInIndex)
+                                 if rec['name'].decode("utf-8") not in fileNamesInIndex)
         for rec in recByIndexAndSize:
             if rec is self.indexRec or rec is self.activelinkRec:
                 rec['target'] = 'manifest'
                 # remember this
-                fileNamesInManifest.add(rec['name'])
+                fileNamesInManifest.add(rec['name'].decode("utf-8"))
                 continue # we already added the size.
             if rec['sizebytes'] + totalsize <= maxsize + redirectSize:
                 rec['target'] = 'manifest'
                 totalsize += rec['sizebytes']
                 maxsize += redirectSize # no redirect needed for this file
                 # remember this
-                fileNamesInManifest.add(rec['name'])
+                fileNamesInManifest.add(rec['name'].decode("utf-8"))
             else:
                 rec['target'] = 'separate'
         # now add more small files to the manifest until less than
         # maxNumberSeparateFiles remain separate.
         separateRecBySize = [i for i in recBySize
-                             if not i['name'] in fileNamesInManifest]
+                             if not i['name'].decode("utf-8") in fileNamesInManifest]
         numSeparate = len(separateRecBySize)
         filesToAdd = max(0, numSeparate - self.sitemgr.maxNumberSeparateFiles)
         for i in range(filesToAdd):
@@ -1433,7 +1433,7 @@ class SiteState:
         def fileMsgLines(n, rec):
             if rec.get('target', 'separate') == 'separate':
                 return [
-                    "Files.%d.Name=%s" % (n, rec['name']),
+                    "Files.%d.Name=%s" % (n, rec['name'].decode("utf-8")),
                     "Files.%d.UploadFrom=redirect" % n,
                     "Files.%d.TargetURI=%s" % (n, rec['uri']),
                 ]
@@ -1454,12 +1454,12 @@ class SiteState:
 
             if hasDDA:
                 return [
-                    "Files.%d.Name=%s" % (n, rec['name']),
+                    "Files.%d.Name=%s" % (n, rec['name'].decode("utf-8")),
                     "Files.%d.UploadFrom=disk" % n,
                     "Files.%d.Filename=%s" % (n, rec['path']),
                 ]
             else:
-                if rec['name'] in self.generatedTextData:
+                if rec['name'].decode("utf-8") in self.generatedTextData:
                     data = self.generatedTextData[rec['name']].encode("utf-8")
                 else:
                     data = file(rec['path'], "rb").read()
@@ -1467,7 +1467,7 @@ class SiteState:
                 # update the sizebytes from the data actually read here.
                 rec['sizebytes'] = len(data)
                 return [
-                    "Files.%d.Name=%s" % (n, rec['name']),
+                    "Files.%d.Name=%s" % (n, rec['name'].decode("utf-8")),
                     "Files.%d.UploadFrom=direct" % n,
                     "Files.%d.DataLength=%s" % (n, rec['sizebytes']),
                 ]

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1098,7 +1098,7 @@ class SiteState:
                     structureChanged = True
                 # for backwards compatibility: files which are missing
                 # the size get the physical size.
-                if not knownrec.has_key('sizebytes'):
+                if 'sizebytes' not in knownrec:
                     knownrec['sizebytes'] = rec['sizebytes']
 
     

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1099,7 +1099,7 @@ class SiteState:
         # if structure has changed, gotta sort and save
         if structureChanged:
             self.needToUpdate = True
-            self.files.sort(lambda r1,r2: cmp(r1['name'], r2['name']))
+            self.files.sort(lambda r1,r2: cmp(r1['name'].decode("utf-8", errors="ignore"), r2['name'].decode("utf-8", errors="ignore")))
             self.save()
             self.log(INFO, "scan: site %s has changed" % self.name)
         else:

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1056,7 +1056,10 @@ class SiteState:
         # firstly, purge deleted files
         # also, pick up records without URIs, or which are already marked as changed
         for name, rec in self.filesDict.items():
-            if not physDict.has_key(name):
+            # generated files never trigger a reupload.
+            if name in self.generatedTextData:
+                continue
+            if name not in physDict:
                 # file has disappeared, remove it and flag an update
                 log(DETAIL, "scan: file %s has been removed" % name)
                 del self.filesDict[name]
@@ -1071,7 +1074,10 @@ class SiteState:
         
         # secondly, add new/changed files we just checked on disk
         for name, rec in physDict.items():
-            if not self.filesDict.has_key(name):
+            # generated files never trigger a reupload.
+            if name in self.generatedTextData:
+                continue
+            if name not in self.filesDict:
                 # new file - add it and flag update
                 log(DETAIL, "scan: file %s has been added" % name)
                 rec['uri'] = ''

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1489,6 +1489,9 @@ class SiteState:
             # skip index and sitemap: we already had them.
             if rec['name'] == self.index:
                 rec['state'] = 'idle'
+                # index is never inserted separately (anymore). FIXME:
+                # Refactor to kill any instance of self.insertingIndex
+                self.insertingIndex = False
                 continue
             if rec['name'] == self.sitemap:
                 rec['state'] = 'idle'

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1306,10 +1306,12 @@ class SiteState:
                 else:
                     data = file(rec['path'], "rb").read()
                 datatoappend.append(data)
+                # update the sizebytes from the data actually read here.
+                rec['sizebytes'] = len(data)
                 return [
                     "Files.%d.Name=%s" % (n, rec['name']),
                     "Files.%d.UploadFrom=direct" % n,
-                    "Files.%d.DataLength=%s" % (n, len(data)),
+                    "Files.%d.DataLength=%s" % (n, rec['sizebytes']),
                 ]
 
             

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1248,11 +1248,11 @@ class SiteState:
                 lines.append(uri)
             lines.append("</pre></body></html>\n")
             
-            self.sitemapRec = {'name': self.sitemap, 'state': 'changed'}
+            self.sitemapRec = {'name': self.sitemap, 'state': 'changed', 'mimetype': 'text/html'}
             self.generatedTextData[self.sitemapRec['name']] = "\n".join(lines)
             raw = self.generatedTextData[self.sitemapRec['name']].encode("utf-8")
             self.sitemapRec['sizebytes'] = len(raw)
-            self.sitemapRec['uri'] = self.chkCalcNode.genchk(data=raw, mimetype=rec['mimetype'])
+            self.sitemapRec['uri'] = self.chkCalcNode.genchk(data=raw, mimetype=self.sitemapRec['mimetype'])
 
         
         # got an actual index and sitemap file?

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -794,7 +794,7 @@ class SiteState:
         # create/insert manifest
         
         self.makeManifest()
-        # print "FOOBAR", self.manifestCmdBuf
+        # FIXME: for some reason the node no longer gets the URI for these.
         self.node._submitCmd(
             self.manifestCmdId, "ClientPutComplexDir",
             rawcmd=self.manifestCmdBuf,

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -626,7 +626,10 @@ class SiteState:
             writeVars(mtype=self.mtype)
             
             w("\n")
-            writeVars("Detailed site contents", files=self.files)
+            # we should not save generated files.
+            physicalfiles = [rec for rec in self.files 
+                            if 'path' in rec]
+            writeVars("Detailed site contents", files=physicalfiles)
     
             f.close()
     

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -25,7 +25,7 @@ testMode = False
 
 defaultPriority = 3
 
-defaultMaxManifestSizeBytes = 1024*512 # 0.5 MiB: This should be just below the size which wants splitfiles. Reduced by 512 bytes per redirect. TODO: Add a larger side-container for additional medium-size files like images.
+defaultMaxManifestSizeBytes = 1024*1024*2 # 2.0 MiB: As used by the freenet default dir inserter. Reduced by 512 bytes per redirect. TODO: Add a larger side-container for additional medium-size files like images. Doing this here, because here we know what is linked in the index file.
 defaultMaxNumberSeparateFiles = 512 # ad hoq - my node sometimes dies at 500 simultaneous uploads. This is half the space in the estimated size of the manifest.
 
 

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -771,12 +771,13 @@ class SiteState:
                 raise raiseException("File %s, has neither path nor generated Text. rec: %s" % (
                     rec['name'], rec))
             # precompute the CHK
-            uri = self.chkCalcNode.genchk(data=raw, mimetype=rec['mimetype'])
+            name = rec['name']
+            uri = self.chkCalcNode.genchk(data=raw, mimetype=rec['mimetype'], TargetFilename=name)
             rec['uri'] = uri
             rec['state'] = 'waiting'
     
             # get a unique id for the queue
-            id = self.allocId(rec['name'])
+            id = self.allocId(name)
     
             # and queue it up for insert, possibly on a different node
             self.node.put(
@@ -786,6 +787,7 @@ class SiteState:
                 priority=self.priority,
                 Verbosity=self.Verbosity,
                 data=raw,
+                TargetFilename=name,
                 async=True,
                 chkonly=testMode,
                 persistence="forever",
@@ -1135,7 +1137,8 @@ class SiteState:
             if not self.indexRec.get('uri', None):
                 self.indexRec['uri'] = self.chkCalcNode.genchk(
                                        data=file(self.indexRec['path'], "rb").read(),
-                                       mimetype=self.mtype)
+                                       mimetype=self.mtype,
+                                       TargetFilename=self.index)
             # yes, remember its uri for the manifest
             self.indexUri = self.indexRec['uri']
             # flag if being inserted
@@ -1148,7 +1151,8 @@ class SiteState:
             if not self.sitemapRec.get('uri', None):
                 self.sitemapRec['uri'] = self.chkCalcNode.genchk(
                                          data=file(self.sitemapRec['path'], "rb").read(),
-                                         mimetype=self.mtype)
+                                         mimetype=self.mtype,
+                                         TargetFilename=self.sitemap)
             # yes, remember its uri for the manifest
             self.sitemapUri = self.sitemapRec['uri']
         
@@ -1243,7 +1247,7 @@ class SiteState:
                     except KeyError:
                         if 'path' in rec:
                             raw = file(rec['path'],"rb").read()
-                            uri = self.chkCalcNode.genchk(data=raw, mimetype=rec['mimetype'])
+                            uri = self.chkCalcNode.genchk(data=raw, mimetype=rec['mimetype'], TargetFilename=rec['name'])
                             rec['uri'] = uri
                 lines.append(uri)
             lines.append("</pre></body></html>\n")
@@ -1252,7 +1256,7 @@ class SiteState:
             self.generatedTextData[self.sitemapRec['name']] = "\n".join(lines)
             raw = self.generatedTextData[self.sitemapRec['name']].encode("utf-8")
             self.sitemapRec['sizebytes'] = len(raw)
-            self.sitemapRec['uri'] = self.chkCalcNode.genchk(data=raw, mimetype=self.sitemapRec['mimetype'])
+            self.sitemapRec['uri'] = self.chkCalcNode.genchk(data=raw, mimetype=self.sitemapRec['mimetype'], TargetFilename=self.sitemap)
 
         
         # got an actual index and sitemap file?

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1352,7 +1352,7 @@ class SiteState:
         reportedlength = sum(rec['sizebytes'] for rec in self.files
                              if rec.get('target', 'separate') == 'manifest')
         if datalength != reportedlength:
-            self.log(ERROR, "The datalength of %s does not match the length reported to the node of %s. This is a bug, please report it to the pyFreenet maintainer." % (datalength, reportedlength))
+            self.log(ERROR, "The datalength of %s to be uploaded does not match the length reported to the node of %s. This is a bug, please report it to the pyFreenet maintainer." % (datalength, reportedlength))
 
     
     #@-node:makeManifest

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1266,10 +1266,7 @@ class SiteState:
                                 mimetype=rec['mimetype'],
                                 TargetFilename=ChkTargetFilename(rec['name']))
                             rec['uri'] = uri
-                    try: # backwards compat: if we have a newly inserted file, add the chkname to the uri.
-                        lines.append(uri + "/" + rec['chkname'])
-                    except KeyError:
-                        lines.append(uri)
+                    lines.append(uri)
             lines.append("</pre></body></html>\n")
             
             self.sitemapRec = {'name': self.sitemap, 'state': 'changed', 'mimetype': 'text/html'}

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1010,7 +1010,7 @@ class SiteState:
         for rec in self.files:
             if rec['state'] != 'idle':
                 stillInserting = True
-        if needToInsertIndex or needToInsertManifest:
+        if needToInsertManifest:
             stillInserting = True
         
         # is insert finally complete?
@@ -1499,6 +1499,8 @@ class SiteState:
                     continue
             # otherwise, ok to add
             msgLines.extend(fileMsgLines(n, rec))
+            # note that the file does not need additional actions.
+            rec['state'] = 'idle'
             # TODO: sum up sizes here to find the error due to which the files get truncated.
     
             # don't forget to up the count

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -25,6 +25,8 @@ testMode = False
 
 defaultPriority = 3
 
+defaultMaxManifestSizeBytes = 1024*1024*2 # 2 MiB
+
 version = 1
 
 minVersion = 0
@@ -428,6 +430,9 @@ class SiteState:
 
         self.index = kw.get('index', 'index.html')
         self.mtype = kw.get('mtype', 'text/html')
+        
+        self.maxManifestSizeBytes = kw.get("maxManifestSizeBytes", 
+                                           defaultMaxManifestSizeBytes)
 
         #print "Verbosity=%s" % self.Verbosity
     
@@ -1202,8 +1207,7 @@ class SiteState:
                 self.indexRec = rec
             if rec['name'] == "activelink.png":
                 self.activelinkRec = rec
-        # we want to stay below 2 MiB
-        maxsize = 2*1024*1024 - 1
+        maxsize = self.maxManifestSizeBytes
         totalsize = 0
         # we add the index as first file, so it is always fast.
         if self.indexRec and self.indexRec['sizebytes'] <= maxsize:

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1309,7 +1309,7 @@ class SiteState:
                 return [
                     "Files.%d.Name=%s" % (n, rec['name']),
                     "Files.%d.UploadFrom=direct" % n,
-                    "Files.%d.DataLength=%s" % (n, rec['sizebytes']),
+                    "Files.%d.DataLength=%s" % (n, len(data)),
                 ]
 
             

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -6,7 +6,7 @@ new persistent SiteMgr class
 
 #@+others
 #@+node:imports
-import sys, os, io, threading, traceback, pprint, time, stat, sha
+import sys, os, io, threading, traceback, pprint, time, stat, sha, json
 
 import fcp
 from fcp import CRITICAL, ERROR, INFO, DETAIL, DEBUG, NOISY
@@ -580,6 +580,7 @@ class SiteState:
             self.log(DETAIL, "save: writing to temp file %s" % tmpFile)
     
             pp = pprint.PrettyPrinter(width=72, indent=2, stream=f)
+            js = json.JSONEncoder(indent=2)
             
             w = f.write
     
@@ -591,7 +592,12 @@ class SiteState:
                     w("# " + comment + "\n")
                 for name, value in kw.items():
                     w(name + " = ")
-                    pp.pprint(value)
+                    # json fails at True, False, None
+                    if value is True or value is False or value is None:
+                        pp.pprint(value)
+                    else:
+                        w(js.encode(value).lstrip())
+                        w("\n")
                 if comment:
                     w("\n")
                 w(tail)

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -794,6 +794,7 @@ class SiteState:
         # create/insert manifest
         
         self.makeManifest()
+        # print "FOOBAR", self.manifestCmdBuf
         self.node._submitCmd(
             self.manifestCmdId, "ClientPutComplexDir",
             rawcmd=self.manifestCmdBuf,
@@ -1219,7 +1220,7 @@ class SiteState:
 
         # check whether we have an activelink.
         for rec in self.files:
-            if rec['name'] == self.index:o
+            if rec['name'] == self.index:
                 self.indexRec = rec
             if rec['name'] == "activelink.png":
                 self.activelinkRec = rec

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1488,8 +1488,10 @@ class SiteState:
         for rec in manifestfiles + separatefiles:
             # skip index and sitemap: we already had them.
             if rec['name'] == self.index:
+                rec['state'] = 'idle'
                 continue
             if rec['name'] == self.sitemap:
+                rec['state'] = 'idle'
                 continue
             # don't add if the file failed to insert
             if not rec['uri']:

--- a/fcp/sitemgr.py
+++ b/fcp/sitemgr.py
@@ -1064,6 +1064,7 @@ class SiteState:
                     # flag an update
                     log(DETAIL, "scan: file %s has changed" % name)
                     knownrec['hash'] = rec['hash']
+                    knownrec['sizebytes'] = rec['sizebytes']
                     knownrec['state'] = 'changed'
                     structureChanged = True
                 # for backwards compatibility: files which are missing

--- a/fcp/upload.py
+++ b/fcp/upload.py
@@ -68,7 +68,7 @@ def help():
                      "  -d, --disk",
                      "     Try to have the node access file on disk directly , it will try then a fallback is provided",
                      "     nb:give the path relative to node filesystem not from where you're running this program",
-                     "        For the direct access to succeed, the absolute path of node and this script must be the same",
+                     "        For the direct access to succeed, the absolute path seen by the node and by this script must be the same",
                      "  -p, --persistence=",
                      "     Set the persistence type, one of 'connection', 'reboot' or 'forever'",
                      "  -g, --global",

--- a/freesitemgr
+++ b/freesitemgr
@@ -123,9 +123,9 @@ def addSite(sitemgr):
         if not os.path.isdir(sitedir):
             print "'%s' is not a directory, try again" % sitedir
             continue
-        elif not os.path.isfile(os.path.join(sitedir, sitemgr.index)):
-            print "'%s' has no %s, try again" % (sitedir, sitemgr.index)
-            continue
+        # elif not os.path.isfile(os.path.join(sitedir, sitemgr.index)):
+        #     print "'%s' has no %s, try again" % (sitedir, sitemgr.index)
+        #     continue
         break
 
     while 1:

--- a/freesitemgr
+++ b/freesitemgr
@@ -12,7 +12,7 @@ A utility to update freesites from within a cron environment
 import sys, os, time, commands, traceback, getopt
 
 import fcp.node
-from fcp.sitemgr import SiteMgr, fixUri
+from fcp.sitemgr import SiteMgr, fixUri, defaultMaxManifestSizeBytes
 
 #@-node:imports
 #@+node:globals
@@ -234,6 +234,7 @@ def help():
     """
     dump help info and exit
     """
+    maxMankiB = defaultMaxManifestSizeBytes / 1024
     print "%s: a console-based USK freesite insertion utility" % progname
     
     print "Usage: %s [options] <command> <args>" % progname
@@ -258,6 +259,12 @@ def help():
     print "  -C, --cron"
     print "     Set options suitable for putting freesitemgr in your crontab,"
     print "     and output a dated header with each site insert"
+    print "  --max-manifest-size=sizekiB"
+    print "     Insert at most files of the given cumulative size as manifest."
+    print "     The files are chosen based on whether they are referenced"
+    print "     in the index-file and by size - smallest first."
+    print "     If you have a site with many small files, you should"
+    print "     increase this to include all of them (default: %s)" % maxMankiB
     print "  --chk-calculation-node=hostname[:port]"
     print "     Use a different node for CHK calculations, which can be a"
     print "     timesaver when inserting large amounts of data into a remote node"
@@ -362,6 +369,9 @@ def main():
 
         if o in ("-m", "--mime-type"):
             opts['mtype'] = a
+
+        if o == '--max-manifest-size':
+            opts['maxManifestSizeBytes'] = int(float(a)*1024)
 
         if o == '--chk-calculation-node':
             chkNode = getChkCalcNode(a)

--- a/freesitemgr
+++ b/freesitemgr
@@ -12,7 +12,7 @@ A utility to update freesites from within a cron environment
 import sys, os, time, commands, traceback, getopt
 
 import fcp.node
-from fcp.sitemgr import SiteMgr, fixUri, defaultMaxManifestSizeBytes
+from fcp.sitemgr import SiteMgr, fixUri, defaultMaxManifestSizeBytes, defaultMaxNumberSeparateFiles
 
 #@-node:imports
 #@+node:globals
@@ -264,7 +264,9 @@ def help():
     print "     The files are chosen based on whether they are referenced in the"
     print "     index-file and by size - smallest first. If you have a site with"
     print "     many small files, you should increase this to include them all"
-    print "     and benefit from better compression (default: %s)" % maxMankiB
+    print "     and benefit from better compression (default: %s)." % maxMankiB
+    print "     It will only go above this to avoid inserting more than"
+    print "     %s files separately." % defaultMaxNumberSeparateFiles
     print "  --chk-calculation-node=hostname[:port]"
     print "     Use a different node for CHK calculations, which can be a"
     print "     timesaver when inserting large amounts of data into a remote node"

--- a/freesitemgr
+++ b/freesitemgr
@@ -330,7 +330,7 @@ def main():
             ["help", "verbose", "config-dir=", "logfile=",
              "max-concurrent=", "force",
              "priority", "cron",
-             "chk-calculation-node=",
+             "chk-calculation-node=", "max-manifest-size=",
              "version", "index", "mime-type",
              ]
             )

--- a/freesitemgr
+++ b/freesitemgr
@@ -261,10 +261,10 @@ def help():
     print "     and output a dated header with each site insert"
     print "  --max-manifest-size=sizekiB"
     print "     Insert at most files of the given cumulative size as manifest."
-    print "     The files are chosen based on whether they are referenced"
-    print "     in the index-file and by size - smallest first."
-    print "     If you have a site with many small files, you should"
-    print "     increase this to include all of them (default: %s)" % maxMankiB
+    print "     The files are chosen based on whether they are referenced in the"
+    print "     index-file and by size - smallest first. If you have a site with"
+    print "     many small files, you should increase this to include them all"
+    print "     and benefit from better compression (default: %s)" % maxMankiB
     print "  --chk-calculation-node=hostname[:port]"
     print "     Use a different node for CHK calculations, which can be a"
     print "     timesaver when inserting large amounts of data into a remote node"

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,16 @@ setup(name="PyFCP",
     )
 
 
+# TODO: Only do this when the installation is to /
+#       currently man-page install is broken with --user
+# some pointers which did not work:
+# import distutils.command.install
+# import distutils.dist
+# i = distutils.command.install.install(distutils.dist.Distribution())
+# i.finalize_options()
+# i.finalize_unix()
+# print i.convert_paths("data")
+# print i.root, i.prefix
 if not doze:
     os.system("cp manpages/*.1 /usr/share/man/man1")
 

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,11 @@ if doze:
 
 from distutils.core import setup
 setup(name="PyFCP",
-      version="0.1.2",
-      description="Freenet FCP access freesite management and XML-RPC modules",
-      author="David McNab",
-      author_email="david@freenet.org.nz",
-       url ="http://127.0.0.1:8888/USK@T4gW1EvwSrR9AOlBT2hFnWy5wK0rtd5rGhf6bp75tVo,E9uFCy0NhiTbR0jVQkY77doaWtxTrkS9kuMrzOtNzSQ,AQABAAE/pyfcp/0",
-
+      version="0.2.0",
+      description="Freenet Client Protocol Helper",
+      author="Arne Babenhauserheide",
+      author_email="arne_bab@web.de",
+      url="http://127.0.0.1:8888/USK@9X7bw5HD2ufYvJuL3qAVsYZb3KbI9~FyRu68zsw5HVg,lhHkYYluqHi7BcW1UHoVAMcRX7E5FaZjWCOruTspwQQ,AQACAAE/pyfcp-api/0/",
       packages = ['fcp'],
       py_modules = [], # ["minibot"], # <- not yet reviewed
       scripts = scripts,


### PR DESCRIPTION
This changes freesite inserts to put the smallest files into a container, up to 2 MiB.

It starts with the smallest files referenced from index.html and includes all files which fit in 2 MiB. Then it checks whether further unreferenced files fit into 2 MiB. Then it adds all further files, starting with the slowest, until there are at most 500 files left out of the container. The rest of the files are uploaded as separate files as before (CHKs).

For graphic-heavy freesites like Freenet_Meltdown, this can reduce the site load time by more than factor 3.